### PR TITLE
build: fix macos app packaging paths

### DIFF
--- a/macos/SteelChatApp/pyproject.toml
+++ b/macos/SteelChatApp/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["macos/SteelChatApp"]
+where = ["."]
+include = ["macos_app_embedded"]
 
 [tool.setuptools.package-data]
 macos_app_embedded = [
@@ -27,7 +28,7 @@ macos_app_embedded = [
 ]
 
 [tool.py2app.app]
-script = "macos/SteelChatApp/macos_app_embedded/main.py"
+script = "macos_app_embedded/main.py"
 
 [tool.py2app.options]
 argv_emulation = true
@@ -39,5 +40,5 @@ resources = [
   "docstore.db",
   "index.html",
   "tmp",
-  "macos/SteelChatApp/resources"
+  "resources"
 ]


### PR DESCRIPTION
## Summary
- update setuptools package discovery to search the project root for the embedded macOS package
- point the py2app script and resources to relative paths without the duplicated macos/SteelChatApp prefix

## Testing
- ./build_app.sh (fails: py2app requires macOS-only dependency pyobjc-framework-WebKit)

------
https://chatgpt.com/codex/tasks/task_e_68d173b73a408323b90551ef1a391be3