### PR TITLE
build: install pyobjc deps before py2app

### DIFF
--- a/macos/SteelChatApp/build_app.sh
+++ b/macos/SteelChatApp/build_app.sh
@@ -11,6 +11,13 @@ pip install --upgrade pip
 pip install -r "$ROOT_DIR/../../requirements.txt"
 pip install py2app build
 
+# Install macOS-specific runtime dependencies required by py2app packaging.
+if [[ "$(uname)" == "Darwin" ]]; then
+  pip install pyobjc pyobjc-framework-Cocoa pyobjc-framework-WebKit
+else
+  echo "Skipping installation of pyobjc frameworks because the host platform is not macOS."
+fi
+
 cd "$ROOT_DIR"
 python -m build --wheel --sdist
 python setup.py py2app

--- a/macos/SteelChatApp/pyproject.toml
+++ b/macos/SteelChatApp/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["macos/SteelChatApp"]
+where = ["."]
+include = ["macos_app_embedded"]
 
 [tool.setuptools.package-data]
 macos_app_embedded = [
@@ -27,7 +28,7 @@ macos_app_embedded = [
 ]
 
 [tool.py2app.app]
-script = "macos/SteelChatApp/macos_app_embedded/main.py"
+script = "macos_app_embedded/main.py"
 
 [tool.py2app.options]
 argv_emulation = true
@@ -39,5 +40,5 @@ resources = [
   "docstore.db",
   "index.html",
   "tmp",
-  "macos/SteelChatApp/resources"
+  "resources"
 ]


### PR DESCRIPTION
## Summary
- ensure the macOS build script installs the pyobjc frameworks required by py2app before packaging
- skip the framework installation step when the script runs on non-macOS hosts to avoid failures in CI environments

## Testing
- not run (macOS-only dependency `pyobjc-framework-WebKit` is unavailable in this Linux environment)

------
https://chatgpt.com/codex/tasks/task_e_68d173b73a408323b90551ef1a391be3