### PR TITLE
build: install pyobjc deps before py2app

### DIFF
--- a/macos/SteelChatApp/build_app.sh
+++ b/macos/SteelChatApp/build_app.sh
@@ -11,6 +11,13 @@ pip install --upgrade pip
 pip install -r "$ROOT_DIR/../../requirements.txt"
 pip install py2app build
 
+# Install macOS-specific runtime dependencies required by py2app packaging.
+if [[ "$(uname)" == "Darwin" ]]; then
+  pip install pyobjc pyobjc-framework-Cocoa pyobjc-framework-WebKit
+else
+  echo "Skipping installation of pyobjc frameworks because the host platform is not macOS."
+fi
+
 cd "$ROOT_DIR"
 python -m build --wheel --sdist
 python setup.py py2app

--- a/macos/SteelChatApp/pyproject.toml
+++ b/macos/SteelChatApp/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["macos/SteelChatApp"]
+where = ["."]
+include = ["macos_app_embedded"]
 
 [tool.setuptools.package-data]
 macos_app_embedded = [
@@ -27,7 +28,7 @@ macos_app_embedded = [
 ]
 
 [tool.py2app.app]
-script = "macos/SteelChatApp/macos_app_embedded/main.py"
+script = "macos_app_embedded/main.py"
 
 [tool.py2app.options]
 argv_emulation = true
@@ -39,5 +40,5 @@ resources = [
   "docstore.db",
   "index.html",
   "tmp",
-  "macos/SteelChatApp/resources"
+  "resources"
 ]

--- a/macos/SteelChatApp/setup.py
+++ b/macos/SteelChatApp/setup.py
@@ -1,4 +1,45 @@
+"""Setuptools entry-point for building the macOS SteelChat app."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
 from setuptools import setup
 
+
+def _load_py2app_config() -> Tuple[List[str], Dict[str, Any]] | None:
+    """Load py2app configuration from pyproject.toml if available."""
+
+    try:
+        import tomllib  # type: ignore[attr-defined]
+    except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    pyproject = Path(__file__).with_name("pyproject.toml")
+    if not pyproject.exists():
+        return None
+
+    config = tomllib.loads(pyproject.read_text())
+    tool_section = config.get("tool", {})
+    py2app_section = tool_section.get("py2app", {})
+
+    app_section = py2app_section.get("app", {})
+    script = app_section.get("script")
+    if not script:
+        return None
+
+    options_section = py2app_section.get("options", {})
+    return [script], dict(options_section)
+
+
 if __name__ == "__main__":
-    setup()
+    kwargs: Dict[str, Any] = {}
+    py2app_config = _load_py2app_config()
+    if py2app_config:
+        app, options = py2app_config
+        kwargs["app"] = app
+        if options:
+            kwargs["options"] = {"py2app": options}
+
+    setup(**kwargs)


### PR DESCRIPTION
## Summary
- ensure the macOS build script installs the pyobjc frameworks required by py2app before packaging
- skip the framework installation step when the script runs on non-macOS hosts to avoid failures in CI environments
- load the py2app app/options configuration from pyproject.toml when invoking setup.py so packaging sees the bundled entry point

## Testing
- python -m compileall macos/SteelChatApp/setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d173b73a408323b90551ef1a391be3