### PR TITLE
fix: load macos entrypoint dependencies when run as script

### DIFF
--- a/macos/SteelChatApp/macos_app_embedded/main.py
+++ b/macos/SteelChatApp/macos_app_embedded/main.py
@@ -16,8 +16,27 @@ from Cocoa import (
 from Foundation import NSAutoreleasePool, NSMakeRect
 from PyObjCTools import AppHelper
 
-from .backend import EmbeddedBackend
-from .ui import build_web_chat_view
+def _load_components():
+    if __package__:
+        from .backend import EmbeddedBackend  # type: ignore
+        from .ui import build_web_chat_view  # type: ignore
+
+        return EmbeddedBackend, build_web_chat_view
+
+    import importlib
+    import pathlib
+    import sys
+
+    package_dir = pathlib.Path(__file__).resolve().parent
+    if str(package_dir) not in sys.path:
+        sys.path.insert(0, str(package_dir))
+
+    backend_module = importlib.import_module("backend")
+    ui_module = importlib.import_module("ui")
+    return backend_module.EmbeddedBackend, ui_module.build_web_chat_view
+
+
+EmbeddedBackend, build_web_chat_view = _load_components()
 
 
 class AppDelegate(NSObject):


### PR DESCRIPTION
## Summary
- add a loader helper in the macOS entrypoint so it can import backend/ui when executed as __main__
- fall back to importing sibling modules directly when __package__ is unset during script execution

## Testing
- `python -m macos.SteelChatApp.macos_app_embedded.main` *(fails: Cocoa not available in Linux CI)*
- `python macos/SteelChatApp/macos_app_embedded/main.py` *(fails: Cocoa not available in Linux CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d18b1a78d88323ba1a879cf5f7018b