### PR TITLE
fix: import embedded modules via importlib

### DIFF
--- a/macos/SteelChatApp/macos_app_embedded/main.py
+++ b/macos/SteelChatApp/macos_app_embedded/main.py
@@ -16,8 +16,26 @@ from Cocoa import (
 from Foundation import NSAutoreleasePool, NSMakeRect
 from PyObjCTools import AppHelper
 
-from .backend import EmbeddedBackend
-from .ui import build_web_chat_view
+def _load_components():
+    import importlib
+    import pathlib
+    import sys
+
+    if __package__:
+        backend_module = importlib.import_module(".backend", __package__)
+        ui_module = importlib.import_module(".ui", __package__)
+        return backend_module.EmbeddedBackend, ui_module.build_web_chat_view
+
+    package_dir = pathlib.Path(__file__).resolve().parent
+    if str(package_dir) not in sys.path:
+        sys.path.insert(0, str(package_dir))
+
+    backend_module = importlib.import_module("backend")
+    ui_module = importlib.import_module("ui")
+    return backend_module.EmbeddedBackend, ui_module.build_web_chat_view
+
+
+EmbeddedBackend, build_web_chat_view = _load_components()
 
 
 class AppDelegate(NSObject):


### PR DESCRIPTION
## Summary
- switch the macOS bundle entry point to load sibling modules with importlib instead of relative imports
- retain the script-execution fallback by inserting the package directory into sys.path before importing backend/ui

## Testing
- `python -m macos.SteelChatApp.macos_app_embedded.main` *(fails: Cocoa not available in Linux environment)*
- `python macos/SteelChatApp/macos_app_embedded/main.py` *(fails: Cocoa not available in Linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18b1a78d88323ba1a879cf5f7018b