### PR TITLE
fix: disable argv emulation in macOS bundle

### DIFF
--- a/macos/SteelChatApp/macos_app_embedded/main.py
+++ b/macos/SteelChatApp/macos_app_embedded/main.py
@@ -16,8 +16,26 @@ from Cocoa import (
 from Foundation import NSAutoreleasePool, NSMakeRect
 from PyObjCTools import AppHelper
 
-from .backend import EmbeddedBackend
-from .ui import build_web_chat_view
+def _load_components():
+    import importlib
+    import pathlib
+    import sys
+
+    if __package__:
+        backend_module = importlib.import_module(".backend", __package__)
+        ui_module = importlib.import_module(".ui", __package__)
+        return backend_module.EmbeddedBackend, ui_module.build_web_chat_view
+
+    package_dir = pathlib.Path(__file__).resolve().parent
+    if str(package_dir) not in sys.path:
+        sys.path.insert(0, str(package_dir))
+
+    backend_module = importlib.import_module("backend")
+    ui_module = importlib.import_module("ui")
+    return backend_module.EmbeddedBackend, ui_module.build_web_chat_view
+
+
+EmbeddedBackend, build_web_chat_view = _load_components()
 
 
 class AppDelegate(NSObject):

--- a/macos/SteelChatApp/pyproject.toml
+++ b/macos/SteelChatApp/pyproject.toml
@@ -31,7 +31,11 @@ macos_app_embedded = [
 script = "macos_app_embedded/main.py"
 
 [tool.py2app.options]
-argv_emulation = true
+# macOS 14+ no longer ships the legacy Carbon framework that py2app uses to
+# implement argv emulation. Leaving the feature enabled causes the bundled app
+# to crash at launch when `ctypes` attempts to load Carbon. Disable it so the
+# bundle starts normally on modern macOS releases.
+argv_emulation = false
 includes = ["fastapi", "uvicorn", "httpx", "pyobjc"]
 resources = [
   "server.py",


### PR DESCRIPTION
## Summary
- switch the macOS bundle entry point to load sibling modules with importlib instead of relative imports
- retain the script-execution fallback by inserting the package directory into sys.path before importing backend/ui
- disable py2app argv emulation to avoid Carbon.framework launch crashes on modern macOS releases

## Testing
- not run (requires macOS environment)


------
https://chatgpt.com/codex/tasks/task_e_68d18b1a78d88323ba1a879cf5f7018b