### PR TITLE
fix: drop jaraco namespace package from py2app config

### DIFF
--- a/macos/SteelChatApp/pyproject.toml
+++ b/macos/SteelChatApp/pyproject.toml
@@ -38,7 +38,7 @@ script = "macos_app_embedded/main.py"
 # bundle starts normally on modern macOS releases.
 argv_emulation = false
 includes = ["fastapi", "uvicorn", "httpx", "pyobjc", "pkg_resources", "jaraco.text"]
-packages = ["jaraco", "jaraco.text"]
+packages = ["jaraco.text"]
 resources = [
   "server.py",
   "tools.py",


### PR DESCRIPTION
## Summary
- remove the `jaraco` namespace package from the py2app configuration because it is namespace-only and cannot be treated as a bootstrap module
- keep the concrete `jaraco.text` package in the bundle so py2app still includes the dependency

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d197b18a6483239342e3e8a419604b